### PR TITLE
Add env variables for mysql settings in tests

### DIFF
--- a/test/TestAll.hx
+++ b/test/TestAll.hx
@@ -11,10 +11,11 @@ class TestAll
 		var cnx = switch Sys.args()[0] {
 			case "sqlite": Sqlite.open("test.db3");
 			case "mysql": Mysql.connect({
-				host: "localhost",
-				user: "ufrontormtest",
-				pass: "ufrontormtest",
-				database: "ufrontormtest",
+				host: Sys.environment().exists("MYSQL_HOST")? Sys.getEnv("MYSQL_HOST") : "localhost",
+				port: Sys.environment().exists("MYSQL_PORT")? Std.parseInt(Sys.getEnv("MYSQL_PORT")) : 3306,
+				user: Sys.environment().exists("MYSQL_USER")? Sys.getEnv("MYSQL_USER") : "root",
+				pass: Sys.environment().exists("MYSQL_PASSWORD")? Sys.getEnv("MYSQL_PASSWORD") : "root",
+				database: Sys.environment().exists("MYSQL_DATABASE")? Sys.getEnv("MYSQL_DATABASE") : "ufrontormtest",
 			});
 			default: throw "Please specify which db connection (sqlite/mysql) you wish to test with";
 		}

--- a/testAll.sh
+++ b/testAll.sh
@@ -1,10 +1,22 @@
+#!/bin/bash
+
+HAXE_COMPILER_PORT=6123
+
 echo "Start Haxe server"
-haxe --wait 6123 &
+if [ -f /tmp/haxe_compiler.$HAXE_COMPILER_PORT.pid ]
+  then
+    kill -9 $(cat /tmp/haxe_compiler.$HAXE_COMPILER_PORT.pid) &> /dev/null ;
+    rm /tmp/haxe_compiler.$HAXE_COMPILER_PORT.pid
+fi
+haxe --wait $HAXE_COMPILER_PORT &
+echo "$!" > /tmp/haxe_compiler.$HAXE_COMPILER_PORT.pid
 
 sleep 1
 
+mkdir -p doc build
+
 echo "Compile #1"
-haxe --connect 6123 test.hxml || exit
+haxe --connect $HAXE_COMPILER_PORT test.hxml || exit
 
 echo "Test neko mysql"
 neko build/neko_test.n mysql || exit
@@ -17,7 +29,7 @@ echo "Test PHP sqlite"
 php build/php_test.php sqlite || exit
 
 echo "Compile #2 (using cache)"
-haxe --connect 6123 test.hxml || exit
+haxe --connect $HAXE_COMPILER_PORT test.hxml || exit
 
 echo "Re-test neko mysql after compile using cache"
 neko build/neko_test.n mysql || exit


### PR DESCRIPTION
environment variables and their defaults are:

````
MYSQL_HOST : localhost
MYSQL_PORT : 3306
MYSQL_USER : root
MYSQL_PASSWORD : root
MYSQL_DATABASE : ufrontormtest
````
ex:
  
````
MYSQL_HOST="localhost" MYSQL_PORT="3306" MYSQL_USER="admin" MYSQL_PASSWORD="goodpassword" MYSQL_DATABASE="ufront_orm" ./testAll.sh
````


this merge also includes a minor refactoring of `testAll.sh`  
to add `$HAXE_COMPILER_PORT`